### PR TITLE
Fix progress bar no longer updating / crash at startup

### DIFF
--- a/sonata/mpdhelper.py
+++ b/sonata/mpdhelper.py
@@ -125,7 +125,11 @@ def _sanitize(tag, return_int=False, str_padding=0):
     # for the mpd tag can be "4", "4/10", and "4,10".
     if not tag:
         return tag
-    tag = str(tag).replace(',', ' ', 1).replace('/', ' ', 1).split()[0]
+    tag = str(tag).replace(',', ' ', 1).replace('/', ' ', 1)
+
+    if not tag.isspace():
+        tag = tag.split()[0]
+        
     if return_int:
         return int(tag) if tag.isdigit() else 0
 


### PR DESCRIPTION
Bug: during playback, often the progress bar hangs and is no longer updated. When closing and restarting, sonata crashes at startup. This behaviour occured with several MPD versions in Debian testing.

Fix: When querying playback progress information, check for strings without any numbers, e.g. don't try to access split()[0] on an whitespace-only string.

Cheers,
Peter
