### PR TITLE
packaging: include glade files in distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,10 @@ setup(
             'pixmaps/*.*',
             'ui/*.ui',
             'ui/*.css',
+            'ui/*.glade',
             'plugins/ui/*.ui',
             'plugins/ui/*.css',
+            'plugins/ui/*.glade'
         ],
     },
     entry_points={


### PR DESCRIPTION
My system-wide installation of sonata did not run due to missing .glade files in the installed package, so I added them to setup.py.
