### PR TITLE
Revert unused caching part of a4ebaff

### DIFF
--- a/sonata/mpdhelper.py
+++ b/sonata/mpdhelper.py
@@ -19,9 +19,6 @@ class MPDClient(object):
             client.use_unicode = True
         self._client = client
         self.logger = logging.getLogger(__name__)
-        self._version = None
-        self._commands = None
-        self._urlhandlers = None
 
     def __getattr__(self, attr):
         """
@@ -56,42 +53,11 @@ class MPDClient(object):
         else:
             return retval
 
-    def connect(self, host, port):
-        self.disconnect()
-        try:
-            self._client.connect(host, port)
-            self._version = self._client.mpd_version.split(".")
-            self._commands = self._client.commands()
-            self._urlhandlers = self._client.urlhandlers()
-        except (socket.error, mpd.MPDError) as e:
-            self.logger.error("Error while connecting to MPD: %s", e)
-
-    def disconnect(self):
-        # Reset to default values
-        self._version = None
-        self._commands = None
-        self._urlhandlers = None
-        try:
-            # We really don't care, if connections breaks, before we
-            # could disconnect.
-            self._client.close()
-            return self._client.disconnect()
-        except:
-            pass
-
     @property
     def version(self):
-        return self._version
+        return tuple(int(part) for part in self._client.mpd_version.split("."))
 
-    @property
-    def commands(self):
-        return self._commands
-
-    @property
-    def urlhandlers(self):
-        return self._urlhandlers
-
-    def update(self,  paths):
+    def update(self, paths):
         if mpd_is_updating(self.status()):
             return
 


### PR DESCRIPTION
(As with the `iconfactory-from-string2`, this is a redo of the `remove-mpdhelper-caching` branch with the appropriate changes.)

We did not use the caching of commands/urlhandlers; additionally, the
urlhandlers was called before password authentication.

Without the caching, we no longer need to wrap connect/disconnect.
