### PR TITLE
fix adding binary streams

### DIFF
--- a/sonata/main.py
+++ b/sonata/main.py
@@ -1320,7 +1320,7 @@ class Base:
         while Gtk.events_pending():
             Gtk.main_iteration()
         if f:
-            if misc.is_binary(f):
+            if type(f) is bytes:
                 # Binary file, just add it:
                 self.mpd.add(item)
             else:

--- a/sonata/misc.py
+++ b/sonata/misc.py
@@ -77,12 +77,6 @@ def _rmgeneric(path, __func__):
         pass
 
 
-def is_binary(f):
-    if '\0' in f: # found null byte
-        return True
-    return False
-
-
 def link_markup(s, enclose_in_parentheses, small, linkcolor):
     if enclose_in_parentheses:
         s = "(%s)" % s


### PR DESCRIPTION
In python3 urllib returns bytes for binary data instead of string.
So we need just to check the type, is_binary isn't needed anymore.
