### PR TITLE
Fix : SyntaxError for 'return'

### DIFF
--- a/sonata/artwork.py
+++ b/sonata/artwork.py
@@ -78,13 +78,13 @@ class ArtworkLocator:
         try:
             files = os.listdir(song_dir)
         except OSError:
-            return None
+            return
 
         get_ext = lambda path: os.path.splitext(path)[1][1:]
 
         artworks = [f for f in files if get_ext(f) in img.VALID_EXTENSIONS]
         if len(artworks) != 1:
-            return None
+            return
 
         yield os.path.join(song_dir, artworks[0])
 


### PR DESCRIPTION
 File "/usr/lib64/python3.2/site-packages/sonata/artwork.py", line 89
    yield os.path.join(song_dir, artworks[0])
SyntaxError: 'return' with argument inside generator
