### PR TITLE
Fix update of progress bar for songs with empty track / disc values

### DIFF
--- a/sonata/mpdhelper.py
+++ b/sonata/mpdhelper.py
@@ -176,7 +176,9 @@ class MPDSong(GObject.GObject):
 
 def cleanup_numeric(value):
     # track and disc can be oddly formatted (eg, '4/10')
-    value = str(value).replace(',', ' ').replace('/', ' ').split()[0]
+    value = str(value).replace(',', ' ').replace('/', ' ')
+    if not value.isspace():
+        value = value.split()[0]
     return int(value) if value.isdigit() else 0
 
 # XXX to be move when we can handle status change in the main interface

--- a/sonata/tests/__init__.py
+++ b/sonata/tests/__init__.py
@@ -105,11 +105,15 @@ class TestMPDSong(unittest.TestCase):
         self.assertEqual(1, MPDSong({'track': '1'}).track)
         self.assertEqual(1, MPDSong({'track': '1/10'}).track)
         self.assertEqual(1, MPDSong({'track': '1,10'}).track)
+        self.assertEqual(0, MPDSong({'track': '/'}).track)
+        self.assertEqual(0, MPDSong({'track': ','}).track)
 
     def test_get_disc_number(self):
         self.assertEqual(1, MPDSong({'disc': '1'}).disc)
         self.assertEqual(1, MPDSong({'disc': '1/10'}).disc)
         self.assertEqual(1, MPDSong({'disc': '1,10'}).disc)
+        self.assertEqual(0, MPDSong({'disc': '/'}).disc)
+        self.assertEqual(0, MPDSong({'disc': ','}).disc)
 
     def test_access_attributes(self):
         song = MPDSong({'foo': 'zz', 'id': '5'})


### PR DESCRIPTION
cleanup_numeric: check against whitespace only strings

Check for whitespace only strings before split()[0] to avoid
IndexError. Fix update of the playback progress bar.