### PR TITLE
Enable gettext translation for glade dialogs.

### DIFF
--- a/sonata/launcher.py
+++ b/sonata/launcher.py
@@ -119,9 +119,17 @@ def run():
         # files.
         locales_path = None
 
+    # Gtk.Builder uses gettext functions from C library. Enable
+    # correct localization for these functions with the locale
+    # module. See:
+    # https://docs.python.org/3/library/locale.html#access-to-message-catalogs
     locale.setlocale(locale.LC_ALL, '')
+
+    # bindtextdomain() is GNU libc specific and may not be available
+    # on other systems (e.g. OSX)
     if hasattr(locale, 'bindtextdomain'):
         locale.bindtextdomain('sonata', locales_path)
+
     gettext.install('sonata', locales_path, names=["ngettext"])
     gettext.textdomain('sonata')
     gettext.bindtextdomain('sonata', locales_path)

--- a/sonata/launcher.py
+++ b/sonata/launcher.py
@@ -48,6 +48,7 @@ if sys.version_info <= (3, 2):
     sys.exit(1)
 
 import gettext
+import locale
 import logging
 import os
 import platform
@@ -118,6 +119,8 @@ def run():
         # files.
         locales_path = None
 
+    locale.setlocale(locale.LC_ALL, '')
+    locale.bindtextdomain('sonata', locales_path)
     gettext.install('sonata', locales_path, names=["ngettext"])
     gettext.textdomain('sonata')
     gettext.bindtextdomain('sonata', locales_path)

--- a/sonata/launcher.py
+++ b/sonata/launcher.py
@@ -120,7 +120,8 @@ def run():
         locales_path = None
 
     locale.setlocale(locale.LC_ALL, '')
-    locale.bindtextdomain('sonata', locales_path)
+    if hasattr(locale, 'bindtextdomain'):
+        locale.bindtextdomain('sonata', locales_path)
     gettext.install('sonata', locales_path, names=["ngettext"])
     gettext.textdomain('sonata')
     gettext.bindtextdomain('sonata', locales_path)


### PR DESCRIPTION
Glade dialogs created by Gtk.Builder use the C library gettext
interface. To enable localization for this interface, use setlocale /
bindtextdomain from the python locale module.

For a detailed explanation see: https://stackoverflow.com/questions/10094335/how-to-bind-a-text-domain-to-a-local-folder-for-gettext-under-gtk3