### PR TITLE
Dynamic Info layout

### DIFF
--- a/sonata/info.py
+++ b/sonata/info.py
@@ -198,6 +198,7 @@ class Info:
         ui.change_cursor(None)
 
     def on_viewport_resize(self, _widget, _event):
+        self.set_lyrics_allocation()
         self.on_artwork_changed(None, self.pixbuf)
 
     def toggle_more(self):
@@ -472,16 +473,32 @@ class Info:
         italic_tag.set_property('style', Pango.Style.ITALIC)
         tag_table.add(italic_tag)
 
+    def set_lyrics_allocation(self):
+        notebook_width = self.info_area.get_allocation().width
+
+        lyrics_requisition = self.lyrics_text.get_preferred_size()[1]
+        lyrics_width = lyrics_requisition.width
+        lyrics_height = lyrics_requisition.height
+
+        if lyrics_width > 0.5 * notebook_width:
+            lyrics_width = 0.5 * notebook_width
+            self.lyrics_scrolledwindow.set_size_request(lyrics_width, lyrics_height)
+        self.lyrics_scrolledwindow.set_min_content_width(lyrics_width)
+
     def _calculate_artwork_size(self):
         if self._imagebox.get_size_request()[0] == -1:
             notebook_width = self.info_area.get_allocation().width
+
             lyrics_width = self.info_lyrics.get_allocation().width
+
             grid = self.info_song_grid
             grid_allocation = grid.get_allocation()
             grid_height = grid_allocation.height
             grid_width = grid.get_preferred_width_for_height(grid_height)[1]
-            fullwidth = notebook_width - lyrics_width - (grid_width)
-            return max(min(0.5 * notebook_width, fullwidth), 150)
+
+            image_max_width = notebook_width - lyrics_width - grid_width
+
+            return max(min(0.5 * notebook_width, image_max_width), 150)
         else:
             return 150
 

--- a/sonata/info.py
+++ b/sonata/info.py
@@ -480,14 +480,18 @@ class Info:
         lyrics_width = lyrics_requisition.width
         lyrics_height = lyrics_requisition.height
 
-        if lyrics_width > 0.5 * notebook_width:
-            lyrics_width = 0.5 * notebook_width
+        if lyrics_width > 0.5 * notebook_width + 10:
+            lyrics_width = 0.5 * notebook_width + 10
+            self.lyrics_scrolledwindow.set_size_request(lyrics_width, lyrics_height)
+        else:
             self.lyrics_scrolledwindow.set_size_request(lyrics_width, lyrics_height)
         self.lyrics_scrolledwindow.set_min_content_width(lyrics_width)
 
     def _calculate_artwork_size(self):
         if self._imagebox.get_size_request()[0] == -1:
-            notebook_width = self.info_area.get_allocation().width
+            notebook_allocation = self.info_area.get_allocation()
+            notebook_width = notebook_allocation.width
+            notebook_height = notebook_allocation.height
 
             lyrics_width = self.info_lyrics.get_allocation().width
 
@@ -496,18 +500,23 @@ class Info:
             grid_height = grid_allocation.height
             grid_width = grid.get_preferred_width_for_height(grid_height)[1]
 
-            image_max_width = notebook_width - lyrics_width - grid_width
+            image_max_width = notebook_width - lyrics_width - grid_width - 10
+            image_max_height = notebook_height - 40
 
-            return max(min(0.5 * notebook_width, image_max_width), 150)
+            box_max_width = max(min(0.5 * notebook_width, image_max_width), 150)
+            box_max_height = max(image_max_height, 150)
+
+            return min(box_max_height, box_max_width)
         else:
             return 150
 
     def on_artwork_changed(self, artwork_obj, pixbuf):
         if pixbuf is not None:
             self.pixbuf = pixbuf
-            box_width = self._calculate_artwork_size()
             image_width = pixbuf.get_width()
-            width = min(image_width, box_width)
+            image_height = pixbuf.get_height()
+            box_size = self._calculate_artwork_size()
+            width = min(min(image_height,image_width), box_size)
 
             (pix2, w, h) = img.get_pixbuf_of_size(pixbuf, width)
             pix2 = img.do_style_cover(self.config, pix2, w, h)
@@ -518,6 +527,7 @@ class Info:
             del pixbuf
 
     def on_artwork_reset(self, artwork_obj):
+        self.pixbuf = None
         self.image.set_from_icon_set(ui.icon('sonata-cd-large'), -1)
 
 

--- a/sonata/info.py
+++ b/sonata/info.py
@@ -480,11 +480,9 @@ class Info:
         lyrics_width = lyrics_requisition.width
         lyrics_height = lyrics_requisition.height
 
-        if lyrics_width > 0.5 * notebook_width + 10:
-            lyrics_width = 0.5 * notebook_width + 10
-            self.lyrics_scrolledwindow.set_size_request(lyrics_width, lyrics_height)
-        else:
-            self.lyrics_scrolledwindow.set_size_request(lyrics_width, lyrics_height)
+        if lyrics_width > 0.5 * notebook_width + 20:
+            lyrics_width = 0.5 * notebook_width + 20
+        self.lyrics_scrolledwindow.set_size_request(lyrics_width, lyrics_height)
         self.lyrics_scrolledwindow.set_min_content_width(lyrics_width)
 
     def _calculate_artwork_size(self):
@@ -500,7 +498,7 @@ class Info:
             grid_height = grid_allocation.height
             grid_width = grid.get_preferred_width_for_height(grid_height)[1]
 
-            image_max_width = notebook_width - lyrics_width - grid_width - 10
+            image_max_width = notebook_width - lyrics_width - grid_width - 20
             image_max_height = notebook_height - 40
 
             box_max_width = max(min(0.5 * notebook_width, image_max_width), 150)

--- a/sonata/info.py
+++ b/sonata/info.py
@@ -199,6 +199,7 @@ class Info:
 
     def on_viewport_resize(self, _widget, _event):
         self.set_lyrics_allocation()
+        self.set_song_info_allocation()
         self.on_artwork_changed(None, self.pixbuf)
 
     def toggle_more(self):
@@ -484,6 +485,15 @@ class Info:
             lyrics_width = 0.5 * notebook_width + 20
         self.lyrics_scrolledwindow.set_size_request(lyrics_width, lyrics_height)
         self.lyrics_scrolledwindow.set_min_content_width(lyrics_width)
+
+    def set_song_info_allocation(self):
+        names = ('title', 'artist', 'album', 'date',
+                 'track', 'genre', 'bitrate')
+        max_width = 0
+        for name in names:
+            text = len(self.info_labels[name].get_text())
+            max_width = max(max_width, text)
+        self.info_labels['file'].set_max_width_chars(2 * max_width)
 
     def _calculate_artwork_size(self):
         if self._imagebox.get_size_request()[0] == -1:

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -706,6 +706,7 @@ class Base:
         self.mainwinhandler = self.window.connect('button_press_event',
                                                   self.on_window_click)
         self.notebook.connect('size-allocate', self.on_notebook_resize)
+        self.notebook.connect('size-allocate', self.info.on_viewport_resize)
         self.notebook.connect('switch-page', self.on_notebook_page_change)
 
         for treeview in [self.current_treeview, self.library_treeview,

--- a/sonata/ui/info.glade
+++ b/sonata/ui/info.glade
@@ -607,6 +607,7 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">1</property>
+                <property name="padding">5</property>
               </packing>
             </child>
           </object>
@@ -624,7 +625,7 @@
           <object class="GtkImage" id="info_tab_image">
             <property name="can_focus">False</property>
             <property name="stock">gtk-file</property>
-            <property name="icon_size">1</property>
+            <property name="icon-size">1</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/sonata/ui/info.glade
+++ b/sonata/ui/info.glade
@@ -538,7 +538,7 @@
                       <object class="GtkScrolledWindow" id="info_page_lyrics_scrolledwindow">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">never</property>
+                        <property name="hscrollbar_policy">automatic</property>
                         <property name="vscrollbar_policy">never</property>
                         <property name="shadow_type">in</property>
                         <child>

--- a/sonata/ui/info.glade
+++ b/sonata/ui/info.glade
@@ -8,504 +8,520 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <object class="GtkBox" id="info_page_v_box">
+          <object class="GtkBox" id="info_page_h_box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <property name="margin">3</property>
             <child>
-              <object class="GtkExpander" id="info_page_song_expander">
+              <object class="GtkBox" id="info_page_v_box">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="info_page_song_box">
+                  <object class="GtkExpander" id="info_page_song_expander">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
                     <child>
-                      <object class="GtkEventBox" id="info_page_song_eventbox">
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkImage" id="info_page_song_image">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">start</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkGrid" id="info_page_song_grid">
+                      <object class="GtkBox" id="info_page_song_box">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">12</property>
-                        <property name="orientation">vertical</property>
-                        <property name="column_spacing">6</property>
                         <child>
-                          <object class="GtkLabel" id="info_song_title_label_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Title:</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">0</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="info_song_artist_label_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Artist:</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">1</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="info_song_album_label_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Album:</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="info_song_date_label_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Date:</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">3</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="info_song_track_label_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Track:</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">4</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="info_song_genre_label_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Genre:</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">5</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="info_song_file_label_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">File:</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">6</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="info_song_bitrate_label_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Bitrate:</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">7</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_artist_h_box">
-                            <property name="visible">True</property>
+                          <object class="GtkEventBox" id="info_page_song_eventbox">
                             <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkEventBox" id="info_song_artist_eventbox">
+                              <object class="GtkImage" id="info_page_song_image">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Launch artist in Wikipedia</property>
-                                <property name="visible_window">False</property>
+                                <property name="halign">start</property>
+                                <property name="valign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkGrid" id="info_page_song_grid">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_left">12</property>
+                            <property name="margin_right">12</property>
+                            <property name="orientation">vertical</property>
+                            <property name="column_spacing">6</property>
+                            <child>
+                              <object class="GtkLabel" id="info_song_title_label_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Title:</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="info_song_artist_label_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Artist:</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="info_song_album_label_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Album:</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="info_song_date_label_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Date:</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="info_song_track_label_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Track:</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="info_song_genre_label_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Genre:</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="info_song_file_label_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">File:</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">6</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="info_song_bitrate_label_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Bitrate:</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">7</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="info_song_artist_h_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <child>
-                                  <object class="GtkLabel" id="info_song_artist_label">
+                                  <object class="GtkEventBox" id="info_song_artist_eventbox">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="tooltip_text" translatable="yes">Launch artist in Wikipedia</property>
+                                    <property name="visible_window">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="info_song_artist_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="wrap">True</property>
+                                        <property name="wrap_mode">word-char</property>
+                                        <property name="xalign">0</property>
+                                        <style>
+                                          <class name="link"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="info_song_album_h_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkEventBox" id="info_song_album_eventbox">
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">Launch album in Wikipedia</property>
+                                    <property name="visible_window">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="info_song_album_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="wrap">True</property>
+                                        <property name="wrap_mode">word-char</property>
+                                        <property name="xalign">0</property>
+                                        <style>
+                                          <class name="link"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="info_song_title_h_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkLabel" id="info_song_title_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
                                     <property name="wrap">True</property>
                                     <property name="wrap_mode">word-char</property>
-                                    <style>
-                                      <class name="link"/>
-                                    </style>
+                                    <property name="selectable">True</property>
+                                    <property name="xalign">0</property>
                                   </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
                               </packing>
                             </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">1</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_album_h_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkEventBox" id="info_song_album_eventbox">
+                              <object class="GtkBox" id="info_song_date_h_box">
+                                <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Launch album in Wikipedia</property>
-                                <property name="visible_window">False</property>
                                 <child>
-                                  <object class="GtkLabel" id="info_song_album_label">
+                                  <object class="GtkLabel" id="info_song_date_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
                                     <property name="wrap">True</property>
                                     <property name="wrap_mode">word-char</property>
-                                    <style>
-                                      <class name="link"/>
-                                    </style>
+                                    <property name="selectable">True</property>
+                                    <property name="xalign">0</property>
                                   </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">3</property>
                               </packing>
                             </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">2</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_title_h_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkLabel" id="info_song_title_label">
+                              <object class="GtkBox" id="info_song_track_h_box">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap_mode">word-char</property>
-                                <property name="selectable">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">0</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_date_h_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="info_song_date_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap_mode">word-char</property>
-                                <property name="selectable">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">3</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_track_h_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="info_song_track_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap_mode">word-char</property>
-                                <property name="selectable">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">4</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_genre_h_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="info_song_genre_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap_mode">word-char</property>
-                                <property name="selectable">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">5</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_file_h_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="info_song_file_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap_mode">word-char</property>
-                                <property name="selectable">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">6</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_bitrate_h_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="info_song_bitrate_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap_mode">word-char</property>
-                                <property name="selectable">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">7</property>
-                            <property name="width">1</property>
-                            <property name="height">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="info_song_links_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkEventBox" id="info_song_links_more_eventbox">
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Toggle extra tags</property>
-                                <property name="visible_window">False</property>
                                 <child>
-                                  <object class="GtkLabel" id="info_song_links_more_label">
+                                  <object class="GtkLabel" id="info_song_track_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <style>
-                                      <class name="link"/>
-                                    </style>
+                                    <property name="wrap">True</property>
+                                    <property name="wrap_mode">word-char</property>
+                                    <property name="selectable">True</property>
+                                    <property name="xalign">0</property>
                                   </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">4</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkEventBox" id="info_song_links_edit_eventbox">
+                              <object class="GtkBox" id="info_song_genre_h_box">
+                                <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Edit song tags</property>
-                                <property name="visible_window">False</property>
                                 <child>
-                                  <object class="GtkLabel" id="info_song_links_edit_label">
+                                  <object class="GtkLabel" id="info_song_genre_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">(edit tags)</property>
-                                    <style>
-                                      <class name="link"/>
-                                    </style>
+                                    <property name="wrap">True</property>
+                                    <property name="wrap_mode">word-char</property>
+                                    <property name="selectable">True</property>
+                                    <property name="xalign">0</property>
                                   </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="info_song_file_h_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkLabel" id="info_song_file_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="wrap">True</property>
+                                    <property name="wrap_mode">word-char</property>
+                                    <property name="selectable">True</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">6</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="info_song_bitrate_h_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkLabel" id="info_song_bitrate_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="wrap">True</property>
+                                    <property name="wrap_mode">word-char</property>
+                                    <property name="selectable">True</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">7</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="info_song_links_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkEventBox" id="info_song_links_more_eventbox">
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">Toggle extra tags</property>
+                                    <property name="visible_window">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="info_song_links_more_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <style>
+                                          <class name="link"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEventBox" id="info_song_links_edit_eventbox">
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">Edit song tags</property>
+                                    <property name="visible_window">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="info_song_links_edit_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">(edit tags)</property>
+                                        <style>
+                                          <class name="link"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">8</property>
+                                <property name="width">2</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">8</property>
-                            <property name="width">2</property>
-                            <property name="height">1</property>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="info_page_song_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Song Info</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
-                <child type="label">
-                  <object class="GtkLabel" id="info_page_song_label">
+                <child>
+                  <object class="GtkExpander" id="info_page_album_expander">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Song Info</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="info_page_album_scrolledwindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="vscrollbar_policy">never</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkTextView" id="info_page_album_textview">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="editable">False</property>
+                            <property name="wrap_mode">word</property>
+                            <property name="left_margin">6</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="info_page_album_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Album Info</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
+                <property name="fill">False</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -522,6 +538,7 @@
                       <object class="GtkScrolledWindow" id="info_page_lyrics_scrolledwindow">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="hscrollbar_policy">never</property>
                         <property name="vscrollbar_policy">never</property>
                         <property name="shadow_type">in</property>
                         <child>
@@ -529,14 +546,13 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="editable">False</property>
-                            <property name="wrap_mode">word</property>
                             <property name="left_margin">6</property>
                           </object>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">True</property>
+                        <property name="fill">False</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
@@ -589,46 +605,8 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
+                <property name="fill">False</property>
                 <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkExpander" id="info_page_album_expander">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <child>
-                  <object class="GtkScrolledWindow" id="info_page_album_scrolledwindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="vscrollbar_policy">never</property>
-                    <property name="shadow_type">in</property>
-                    <child>
-                      <object class="GtkTextView" id="info_page_album_textview">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="editable">False</property>
-                        <property name="wrap_mode">word</property>
-                        <property name="left_margin">6</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child type="label">
-                  <object class="GtkLabel" id="info_page_album_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Album Info</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -646,7 +624,7 @@
           <object class="GtkImage" id="info_tab_image">
             <property name="can_focus">False</property>
             <property name="stock">gtk-file</property>
-            <property name="icon-size">1</property>
+            <property name="icon_size">1</property>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Fixes #60 
Based on ideas from #77 
I moved the lyrics panel to the right side of the window, next to album cover and song info.
Cover art, lyrics and song info size change based on the following rules:
* Lyrics width must not exceed 50% of window width
* Song info width must show one line per attribute, except the file path, because the path is usually much longer than title, album or artist
* Cover width must not exceed 50% of window width
* Cover height must not exceed window height
* Cover size must not be larger than the actual size of the cover image

![window](https://cloud.githubusercontent.com/assets/7817714/8190918/decfb888-1465-11e5-9da2-02ef5441de91.png)
