### PR TITLE
Playlists

### DIFF
--- a/sonata/library.py
+++ b/sonata/library.py
@@ -150,6 +150,8 @@ class Library:
                                                  Gtk.IconSize.LARGE_TOOLBAR)
         self.sonatapb = self.library.render_icon('sonata',
                                                  Gtk.IconSize.LARGE_TOOLBAR)
+        self.playlistpb = self.library.render_icon('sonata-play',     #Rocus
+                                                 Gtk.IconSize.LARGE_TOOLBAR)
 
         # list of the library views: (id, name, icon name, label)
         self.VIEWS = [
@@ -543,6 +545,11 @@ class Library:
                             [self.sonatapb, data,
                              formatting.parse(self.config.libraryformat, item,
                                               True)])]
+                elif 'playlist' in item:   #Rocus
+                    name = os.path.basename(item['playlist'])
+                    data = SongRecord(path=item["playlist"])
+                    bd += [('p' + str(name).lower(), [self.playlistpb, data,
+                                                      misc.escape_html(name)])]
             bd.sort(key=operator.itemgetter(0))
         return bd
 
@@ -1076,8 +1083,7 @@ class Library:
                 return
         value = self.librarydata.get_value(self.librarydata.get_iter(path), 1)
         icon = self.librarydata.get_value(self.librarydata.get_iter(path), 0)
-        if icon == self.sonatapb:
-            # Song found, add item
+        if icon == self.sonatapb or icon == self.playlistpb:     #Rocus
             self.on_add_item(self.library)
         elif value.path == "..":
             self.library_browse_parent(None)

--- a/sonata/library.py
+++ b/sonata/library.py
@@ -150,7 +150,7 @@ class Library:
                                                  Gtk.IconSize.LARGE_TOOLBAR)
         self.sonatapb = self.library.render_icon('sonata',
                                                  Gtk.IconSize.LARGE_TOOLBAR)
-        self.playlistpb = self.library.render_icon('sonata-play',     #Rocus
+        self.playlistpb = self.library.render_icon('sonata-play',     #####
                                                  Gtk.IconSize.LARGE_TOOLBAR)
 
         # list of the library views: (id, name, icon name, label)
@@ -545,7 +545,7 @@ class Library:
                             [self.sonatapb, data,
                              formatting.parse(self.config.libraryformat, item,
                                               True)])]
-                elif 'playlist' in item:   #Rocus
+                elif 'playlist' in item:   ######
                     name = os.path.basename(item['playlist'])
                     data = SongRecord(path=item["playlist"])
                     bd += [('p' + str(name).lower(), [self.playlistpb, data,
@@ -1083,7 +1083,7 @@ class Library:
                 return
         value = self.librarydata.get_value(self.librarydata.get_iter(path), 1)
         icon = self.librarydata.get_value(self.librarydata.get_iter(path), 0)
-        if icon == self.sonatapb or icon == self.playlistpb:     #Rocus
+        if icon == self.sonatapb or icon == self.playlistpb:     ######
             self.on_add_item(self.library)
         elif value.path == "..":
             self.library_browse_parent(None)

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -1234,7 +1234,7 @@ class Base:
             if self.current_tab == self.TAB_LIBRARY:
                 items = self.library.get_path_child_filenames(True)
                 self.mpd.command_list_ok_begin()
-                for item in items:     #Rocus
+                for item in items:     ######
                      if item.endswith('.pls') or item.endswith('.PLS') or \
                         item.endswith('.m3u') or item.endswith('.M3U'):
                             self.mpd.load(item)

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -1234,8 +1234,12 @@ class Base:
             if self.current_tab == self.TAB_LIBRARY:
                 items = self.library.get_path_child_filenames(True)
                 self.mpd.command_list_ok_begin()
-                for item in items:
-                    self.mpd.add(item)
+                for item in items:     #Rocus
+                     if item.endswith('.pls') or item.endswith('.PLS') or \
+                        item.endswith('.m3u') or item.endswith('.M3U'):
+                            self.mpd.load(item)
+                     else:
+                            self.mpd.add(item)
                 self.mpd.command_list_end()
             elif self.current_tab == self.TAB_PLAYLISTS:
                 model, selected = self.playlists_selection.get_selected_rows()


### PR DESCRIPTION
MPD can load playlists (located on the MPD server). Sonata ignores those playlists. This modification shows playlists in the library view. You can add them to the current queue. If the playlist contains mp3's you can find these mp3's in your current queue: they will be played in due time. If the playlist contains one or more URL's (of radio streams), they will also be added to the current queue (and played later). 

Most MPD clients ignore playlists, gmpc does not. Sonata changed by the suggested modifications in library.py and main.py will work as gmpc as far as playlists are concerned.

The playlist as implemented sofar in sonata (see playlist tab) are stored in the client (whithout directory structure).  This modification stores them at the MPD server and they can be structured in directories.

![screenshot from 2015-06-19 13 35 06](https://cloud.githubusercontent.com/assets/3619404/8252654/124eb3ac-1688-11e5-8077-fb975ad4504b.png)

![screenshot from 2015-06-19 13 32 23](https://cloud.githubusercontent.com/assets/3619404/8252626/d0a1c0e8-1687-11e5-90d5-13a328eee4f5.png)
