### PR TITLE
Fix #73: cover and text updates in full-screen mode

### DIFF
--- a/sonata/main.py
+++ b/sonata/main.py
@@ -699,6 +699,7 @@ class Base:
         self.randommenu.connect('toggled', self.on_random_clicked)
         self.repeatmenu.connect('toggled', self.on_repeat_clicked)
         self.cursonglabel1.connect('notify::label', self.on_currsong_notify)
+        self.cursonglabel1.connect('notify::label', self.fullscreen.on_text_changed)
         self.progressbar.connect('notify::fraction',
                                  self.on_progressbar_notify_fraction)
         self.progressbar.connect('notify::text',
@@ -3148,6 +3149,9 @@ class FullscreenApp:
     def on_artwork_changed(self, artwork_obj, pixbuf):
         self.currentpb = pixbuf
         self.set_image()
+
+    def on_text_changed(self, line1, line2):
+        self.set_text()
 
     def reset(self, *args, **kwargs):
         self.image.set_from_icon_set(ui.icon('sonata-cd'), -1)

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -3146,9 +3146,8 @@ class FullscreenApp:
         self.window.hide()
 
     def on_artwork_changed(self, artwork_obj, pixbuf):
-        self.set_text()
-        self.set_image()
         self.currentpb = pixbuf
+        self.set_image()
 
     def reset(self, *args, **kwargs):
         self.image.set_from_icon_set(ui.icon('sonata-cd'), -1)


### PR DESCRIPTION
This is an attempt at fixing #73 regarding artwork and text updates in full-screen mode.
