### PR TITLE
Fix GTK startup CSS warnings

### DIFF
--- a/sonata/launcher.py
+++ b/sonata/launcher.py
@@ -30,7 +30,7 @@ import logging
 import os
 import platform
 import threading  # needed for interactive shell
-
+import gi
 
 def run():
     """Main entry point of Sonata"""
@@ -156,6 +156,7 @@ def run():
 
     if not args.skip_gui:
         # importing gtk does sys.setdefaultencoding("utf-8"), sets locale etc.
+        gi.require_version('Gtk', '3.0')
         from gi.repository import Gtk, Gdk
     else:
         class FakeModule:

--- a/sonata/ui/sonata.css
+++ b/sonata/ui/sonata.css
@@ -4,11 +4,11 @@ GtkLabel.current_label {
 }
 
 GtkLabel.fullscreen_label {
-  font-size: 19.5;/*= 20000 / 1024 */
+  font-size: 19.5px;/*= 20000 / 1024 */
 }
 
 GtkLabel.fullscreen_label2 {
-  font-size: 11.7;/*= 12000/1024 */
+  font-size: 11.7px;/*= 12000/1024 */
 }
 
 GtkLabel.fullscreen_label,


### PR DESCRIPTION
The sonata.css file provided font sizes without explicitly stated
unit. This commit fixes the warnings at startup by adding the default px unit.