### PR TITLE
Add restart track behavior on previous track if current position is 5+ seconds

### DIFF
--- a/sonata/consts.py
+++ b/sonata/consts.py
@@ -64,6 +64,7 @@ LIB_LEVEL_ARTIST = 1
 LIB_LEVEL_ALBUM = 2
 LIB_LEVEL_SONG = 3
 NUM_ARTISTS_FOR_VA = 2
+PREV_TRACK_RESTART = 5
 
 # the names of the plug-ins that will be enabled by default
 DEFAULT_PLUGINS = [

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -2515,9 +2515,17 @@ class Base:
             self.iterate_now()
 
     def mpd_prev(self, _widget, _key=None):
-        if self.conn:
-            self.mpd.previous()
-            self.iterate_now()
+	if self.conn:
+            if self.status_is_play_or_pause():
+                at, length = [int(c) for c in self.status['time'].split(':')]
+                if at >= consts.PREV_TRACK_RESTART:
+                    self.seek(int(self.status['song']), 0)
+                else:
+                    self.mpd.previous()
+                    self.iterate_now()
+            else:
+                self.mpd.previous()
+                self.iterate_now()
 
     def mpd_next(self, _widget, _key=None):
         if self.conn:

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -2517,15 +2517,15 @@ class Base:
     def mpd_prev(self, _widget, _key=None):
 	if self.conn:
             if self.status_is_play_or_pause():
+		# Try to rewind the song if we are advanced enough...
                 at, length = [int(c) for c in self.status['time'].split(':')]
                 if at >= consts.PREV_TRACK_RESTART:
                     self.seek(int(self.status['song']), 0)
-                else:
-                    self.mpd.previous()
-                    self.iterate_now()
-            else:
-                self.mpd.previous()
-                self.iterate_now()
+		    return
+
+	    # otherwise, just go to the previous song
+            self.mpd.previous()
+            self.iterate_now()
 
     def mpd_next(self, _widget, _key=None):
         if self.conn:


### PR DESCRIPTION
As discussed in issue #101 here's a pull request to add the restart track behavior when the previous track button is pressed and the current playback position is 5 or more seconds. While this behavior does not appear to be present in any other MPD-based clients, it's common enough in other media players to be worth looking into in my opinion.

Thanks,

Mike