### PR TITLE
Explicitly request the right version of various GIRs

### DIFF
--- a/sonata/launcher.py
+++ b/sonata/launcher.py
@@ -156,7 +156,10 @@ def run():
 
     if not args.skip_gui:
         # importing gtk does sys.setdefaultencoding("utf-8"), sets locale etc.
+        gi.require_version('Gdk', '3.0')
+        gi.require_version('GdkPixbuf', '2.0')
         gi.require_version('Gtk', '3.0')
+        gi.require_version('Pango', '1.0')
         from gi.repository import Gtk, Gdk
     else:
         class FakeModule:


### PR DESCRIPTION
Otherwise, there's no guarantee that we won't get a newer version with an incompatible API.

---

In particular this is necessary if you happen to have a beta version of Gdk 4 installed.