### PR TITLE
library: Cope with MPDClient.list API change

### DIFF
--- a/sonata/library.py
+++ b/sonata/library.py
@@ -782,12 +782,22 @@ class Library:
                 else:
                     items = self.mpd.list(itemtype, *s)
                 for item in items:
+                    if isinstance(item, dict):
+                        if itemtype in item:
+                            item = item[itemtype]
+                        else:
+                            continue
                     if len(item) > 0:
                         results.append(item)
         else:
             if genre is None and artist is None and album is None and year \
                is None:
                 for item in self.mpd.list(itemtype):
+                    if isinstance(item, dict):
+                        if itemtype in item:
+                            item = item[itemtype]
+                        else:
+                            continue
                     if len(item) > 0:
                         results.append(item)
         if ignore_case:


### PR DESCRIPTION
As a result of grouping support being added in python-mpd2 1.1.0, list() now returns a list of dicts like `[{"album", "OK Computer"}]` instead of a list of simple strings like `["OK Computer"]`. Cope with either way.

This changed in: https://github.com/Mic92/python-mpd2/pull/106