### PR TITLE
library: Try to replace deprecated popup_for_device with popup_at_widget

### DIFF
--- a/sonata/library.py
+++ b/sonata/library.py
@@ -224,8 +224,15 @@ class Library:
         self.librarymenu.attach_to_widget(self.libraryview, None)
 
     def library_view_popup(self, button):
-        self.librarymenu.popup(None, None, self.library_view_position_menu,
-                               button, 1, 0)
+        if hasattr(self.librarymenu, 'popup_at_widget'):
+            self.librarymenu.popup_at_widget(button,
+                                             Gdk.Gravity.CENTER,
+                                             Gdk.Gravity.NORTH_WEST,
+                                             None)
+        else:
+            self.librarymenu.popup(None, None,
+                                   self.library_view_position_menu,
+                                   button, 1, 0)
 
     def library_view_position_menu(self, _menu, button):
         alloc = button.get_allocation()


### PR DESCRIPTION
popup() is a compatibility wrapper for popup_for_device(), which was deprecated in Gtk 3.22 in favour of popup_at_widget() and popup_at_pointer(). Pop up the menu over the middle of the button.

----

As well as avoiding a deprecated function, this seems to result in the menu being misplaced less often.

The Gdk.Gravity values I chose result in the top left corner of the menu being positioned at the centre of the button, aligning the two points marked x:

```
+-----+
|     |
| --- |
| \x/ |     x-----
|  v  |     | Filesystem
|     |     | Artists
+-----+     | ...
```