### PR TITLE
Add keywords to the .desktop file

### DIFF
--- a/sonata.desktop
+++ b/sonata.desktop
@@ -8,3 +8,4 @@ Type=Application
 Icon=sonata
 Categories=GTK;AudioVideo;Player;
 StartupNotify=true
+Keywords=Player;Music;Audio;


### PR DESCRIPTION
It's recommended to have a Keywords entry in .desktop files.
http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
https://wiki.gnome.org/GnomeGoals/DesktopFileKeywords

---

Forwarded from Debian.