### PR TITLE
Avoid problematic uses of 'is'

### DIFF
--- a/sonata/main.py
+++ b/sonata/main.py
@@ -2873,7 +2873,7 @@ class Base:
 
         # FIXME when new UI is done, the top branch expression wins
         if notebook.get_tab_label(tab).get_children and \
-            len(notebook.get_tab_label(tab).get_children()) is 2:
+            len(notebook.get_tab_label(tab).get_children()) == 2:
             child = notebook.get_tab_label(tab).get_children()[1]
         else:
             child = notebook.get_tab_label(tab).get_child().get_children()[1]

--- a/sonata/tagedit.py
+++ b/sonata/tagedit.py
@@ -281,7 +281,7 @@ class TagEditor:
                 if len(tag_value) == 0:
                     tag_value = '0'
                 tag_value = int(tag_value)
-            if field is 'comment':
+            if field == 'comment':
                 if len(tag_value) == 0:
                     tag_value = ' '
             setattr(tag, field, tag_value)


### PR DESCRIPTION
The 'is' operator compares by object identity, which is not usually
what you want unless comparing with singleton objects like None.
Python 3.8 warns about suspicious uses of 'is' during byte-compilation.

As an implementation detail, CPython interns small integers, so
"1 + 1 is 2" is likely to be true, although this is not an API guarantee.

However, "field is 'comment'" is unlikely to be true, because CPython
allocates separate string objects for each instance of the same long
string.