### PR TITLE
Don't pass use_unicode to MPDClient constructor on Python 3

### DIFF
--- a/sonata/mpdhelper.py
+++ b/sonata/mpdhelper.py
@@ -21,6 +21,7 @@ import logging
 import operator
 import os
 import socket
+import sys
 
 from gi.repository import GObject
 import mpd
@@ -30,12 +31,18 @@ from sonata.misc import remove_list_duplicates
 
 class MPDClient:
     def __init__(self, client=None):
-        if client is None:
-            # Yeah, we really want some unicode returned, otherwise we'll have
-            # to do it by ourselves.
-            client = mpd.MPDClient(use_unicode=True)
-        else:
-            client.use_unicode = True
+
+        if sys.version_info < (3, 0):
+            if client is None:
+                # Yeah, we really want some unicode returned, otherwise
+                # we'll have to do it by ourselves.
+                client = mpd.MPDClient(use_unicode=True)
+            else:
+                client.use_unicode = True
+        elif client is None:
+            # On Python 3, python-mpd2 always uses Unicode
+            client = mpd.MPDClient()
+
         self._client = client
         self.logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
python-mpd2 2.0.0 dropped Python 2 support and removed this constructor
parameter. It has no effect under Python 3.

---

In Debian's python3-mpd package I've added back compatibility with the use_unicode parameter (see https://github.com/Mic92/python-mpd2/pull/142) but I don't know whether that will be accepted upstream.