### PR TITLE
update setup.py, use importlib instead of pkg_resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Requirements
 
 In order to run Sonata, you will need the following dependencies:
 
-* Python >= 3.2
+* Python >= 3.3
 * `PyGObject`_ (aka Python GObject Introspection) (3.7.4 or more recommended,
   earlier versions may also work)
 * GTK >= 3.4

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,13 @@
 #!/usr/bin/env python
 
 import sys
-if sys.version_info <= (3, 2):
-    sys.stderr.write("Sonata requires Python 3.2+\n")
+if sys.version_info <= (3, 3):
+    sys.stderr.write("Sonata requires Python 3.3+\n")
     sys.exit(1)
 
 import os
 from setuptools import setup
 from sonata.version import version
-
-
-tests_require = []
-if sys.version_info < (3, 3):
-    # Available as unittest.mock since 3.3
-    tests_require.append('mock')
 
 
 def newer(source, generated):
@@ -74,12 +68,12 @@ setup(
     description='GTK+ client for the Music Player Daemon (MPD).',
     author='Scott Horowitz',
     author_email='stonecrest@gmail.com',
+    license='GNU General Public License (GPL)',
     url='http://www.nongnu.org/sonata/',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: X11 Applications',
         'Intended Audience :: End Users/Desktop',
-        'License :: GNU General Public License (GPL)',
         'Operating System :: Linux',
         'Programming Language :: Python',
         'Topic :: Multimedia :: Sound :: Players',
@@ -101,8 +95,6 @@ setup(
             'sonata=sonata.launcher:run',
         ]
     },
-    test_suite='sonata.tests',
-    tests_require=tests_require,
 )
 try:
     os.remove("sonata/genversion.py")

--- a/sonata/launcher.py
+++ b/sonata/launcher.py
@@ -20,8 +20,8 @@
 """Sonata is a simple GTK+ client for the Music Player Daemon."""
 
 import sys
-if sys.version_info <= (3, 2):
-    sys.stderr.write("Sonata requires Python 3.2+\n")
+if sys.version_info <= (3, 3):
+    sys.stderr.write("Sonata requires Python 3.3+\n")
     sys.exit(1)
 
 import gettext

--- a/sonata/main.py
+++ b/sonata/main.py
@@ -35,7 +35,7 @@ import threading
 
 from gi.repository import Gtk, Gdk, GdkPixbuf, Gio, GLib, Pango
 
-import pkg_resources
+import importlib.resources
 
 import sonata.mpdhelper as mpdh
 
@@ -188,7 +188,7 @@ class Base:
         self.provider = ui.css_provider('sonata')
 
         icon_factory_src = ui.builder_string('icons')
-        icon_path = pkg_resources.resource_filename(__name__, "pixmaps")
+        icon_path = importlib.resources.files(__name__).joinpath("pixmaps")
         icon_factory_src = icon_factory_src.format(base_path=icon_path)
         self.builder.add_from_string(icon_factory_src)
         icon_factory = self.builder.get_object('sonata_iconfactory')

--- a/sonata/ui.py
+++ b/sonata/ui.py
@@ -18,7 +18,7 @@
 
 import logging
 import os
-import pkg_resources
+import importlib.resources
 import sys
 
 from gi.repository import Gtk, Gdk
@@ -30,8 +30,7 @@ logger = logging.getLogger(__name__)
 def builder(ui_file, relative_to='.'):
     builder = Gtk.Builder()
     builder.set_translation_domain('sonata')
-    ui_path = pkg_resources.resource_filename(
-        'sonata', os.path.join(relative_to, 'ui', ui_file + ".glade"))
+    ui_path = str(importlib.resources.files('sonata') / os.path.join(relative_to, 'ui', ui_file + ".glade"))
     logger.debug('Loading %s', ui_path)
     builder.add_from_file(ui_path)
 
@@ -39,8 +38,7 @@ def builder(ui_file, relative_to='.'):
 
 def css_provider(css_file, relative_to='.'):
     provider = Gtk.CssProvider()
-    css_path = pkg_resources.resource_filename(
-        'sonata', os.path.join(relative_to, 'ui', css_file + ".css"))
+    css_path = str(importlib.resources.files('sonata') / os.path.join(relative_to, 'ui', css_file + ".css"))
     logger.debug('Loading %s', css_path)
     provider.load_from_path(css_path)
     screen = Gdk.Screen.get_default()
@@ -51,8 +49,7 @@ def css_provider(css_file, relative_to='.'):
     return provider
 
 def builder_string(ui_file, relative_to='.'):
-    ui_path = pkg_resources.resource_filename(
-        'sonata', os.path.join(relative_to, 'ui', ui_file + ".glade"))
+    ui_path = str(importlib.resources.files('sonata') / os.path.join(relative_to, 'ui', ui_file + ".glade"))
     logger.debug('Loading %s', ui_path)
 
     with open(ui_path, 'r') as builder_file:


### PR DESCRIPTION
setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'test_suite'  warnings.warn(msg)
setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'tests_require'  warnings.warn(msg)
setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.

sonata/main.py:38: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.