### PR TITLE
launcher: Assume the GDK lock is already held in GtkApplication::activate

### DIFF
--- a/sonata/launcher.py
+++ b/sonata/launcher.py
@@ -191,7 +191,6 @@ def run():
 
 
     def on_application_activate(application):
-        Gdk.threads_enter()
         windows = application.get_windows()
 
         if windows:
@@ -200,7 +199,6 @@ def run():
         else:
             sonata = main.Base(args)
             sonata.window.set_application(application)
-        Gdk.threads_leave()
 
     app = Gtk.Application(application_id="org.MPD.Sonata")
     app.connect("activate", on_application_activate)


### PR DESCRIPTION
GtkApplication is documented to acquire the GDK lock when we receive `::activate` from another process. The GDK lock is not guaranteed to be a recursive lock, and if it is not, we will deadlock if we try to acquire it when already acquired.

This particular application does not seem to emit the activate signal manually, but if it does at some point in future, it will need to make sure to emit the signal in a context where it would be safe to call GTK functions.

See also [`docs/guide/threading.rst` in pygobject](https://gitlab.gnome.org/GNOME/pygobject/-/blob/main/docs/guide/threading.rst?ref_type=heads).

Resolves: https://github.com/multani/sonata/issues/164